### PR TITLE
fixed missing filter value from post type save

### DIFF
--- a/includes/to-post-type.php
+++ b/includes/to-post-type.php
@@ -347,7 +347,7 @@ function cf_custom_fields_capture_entry($config, $form){
 
 			}
 		}
-
+                $value = apply_filters('caldera_forms_save_field', $value, $form['fields'][$field] );
 
 
 		if(empty($form['fields'][$field])){


### PR DESCRIPTION
Documentation for caldera says 'caldera_forms_save_field' is the filter to use to get the form data before it is saved.  However this filter was not setup for the to post type functionality.  Added.