### PR TITLE
Fixed forwarding empty multi-select fields.

### DIFF
--- a/includes/to-post-type.php
+++ b/includes/to-post-type.php
@@ -369,15 +369,14 @@ function cf_custom_fields_capture_entry($config, $form){
 		
 	}
 	
-	// get all submission data
-	$data = Caldera_Forms::get_submission_data( $form );
 	update_post_meta( $entry_id, '_cf_form_id', $form['ID'] );
-	foreach ( $data as $field_id => $value ) {
+	
+	//multiple select fields don't get POST-ed when there's no option selected,
+	//so they might not appear in submission_data, so loop the form fields instead
+  
+	foreach ( $form['fields'] as $field_id => $field ) {
+		$value = Caldera_Forms::get_field_data($field_id, $form);
 		
-		$field = Caldera_Forms_Field_Util::get_field( $field_id, $form );
-		if( empty( $field ) ){
-			continue;
-		}
 		$slug = $field[ 'slug' ];
 		if( in_array( $slug, $mapped_post_fields ) || in_array( $field[ 'ID' ], $mapped_post_fields ) ){
 			continue;


### PR DESCRIPTION
select2 doesn't include a field in the POST if multiple selections are allowed but none were selected by the user. The processor normally forwards the submissions to a filter before saving, but the submission_data did not include such empty multi-select fields. The value of such an empty field, as returned by get_field_data, is null so update_post_meta still doesn't save it, but this patch allows a custom filter to handle it more easily (e.g converting null values to empty strings, arrays to comma separated lists etc.).