### PR TITLE
Empty image field still saving last saved image as featured image

### DIFF
--- a/includes/to-post-type.php
+++ b/includes/to-post-type.php
@@ -342,6 +342,7 @@ function cf_custom_fields_capture_entry($config, $form){
 			$featured_image = 	Caldera_Forms_Transient::get_transient( 'cf_cf_featured_' . $form[ 'ID' ] );
 			if (  is_numeric( $featured_image ) ) {
 				set_post_thumbnail( $post, $featured_image );
+                Caldera_Forms_Transient::delete_transient( 'cf_cf_featured_' . $form[ 'ID' ] );
 			}
 			
 		}


### PR DESCRIPTION
Fix #45 When an image field is set to be saved as the featured image and no file is selected in that field, the last image saved was still saved as the featured image